### PR TITLE
Add whole list to cache once rather than adding to cache in every iteration of the loop.

### DIFF
--- a/ledger_api_client/ledger_models.py
+++ b/ledger_api_client/ledger_models.py
@@ -365,6 +365,7 @@ class PermissionsMixinRO(models.Model):
         else:
             sgp_groups = json.loads(sgp_cache)
         return sgp_groups
+
     def system_group_permision_list(self,system_group_id):
         from ledger_api_client import managed_models
         permission_list = []
@@ -377,7 +378,7 @@ class PermissionsMixinRO(models.Model):
                     perm_name = p.content_type.app_label+"."+p.codename
                     app_label = p.content_type.app_label
                     permission_list.append({"id":p.id, "perm_name" : perm_name, 'app_label': app_label})
-                    cache.set(cache_name_pl,json.dumps(permission_list), 86400)
+                cache.set(cache_name_pl,json.dumps(permission_list), 86400)
         else:
             permission_list = json.loads(pl_cache)
 

--- a/ledger_api_client/managed_models.py
+++ b/ledger_api_client/managed_models.py
@@ -54,7 +54,7 @@ class SystemGroup(models.Model):
             spg = SystemGroupPermission.objects.filter(system_group=self)
             for p in spg:
                 spg_array.append(p.emailuser.id)
-                cache.set("managed_models.SystemGroup.get_system_group_member_ids:"+str(self.id), json.dumps(spg_array), 86400)
+            cache.set("managed_models.SystemGroup.get_system_group_member_ids:"+str(self.id), json.dumps(spg_array), 86400)
         else:
             spg_array = json.loads(spg_array_cache)
         return spg_array


### PR DESCRIPTION
Improves permission checking perforance quite substantially in local testing.