### PR TITLE
ADMINS setting fix for django >=3.2 

### DIFF
--- a/ledger_api_client/settings_base.py
+++ b/ledger_api_client/settings_base.py
@@ -1,3 +1,5 @@
+import django
+
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib import messages
 
@@ -86,10 +88,16 @@ if SESSION_COOKIE_DOMAIN:
 
 
 # Email settings
-ADMINS = ('asi@dpaw.wa.gov.au',)
 EMAIL_HOST = decouple.config('EMAIL_HOST', default='email.host')
 EMAIL_PORT = decouple.config('EMAIL_PORT', default=25)
-EMAIL_FROM = decouple.config('EMAIL_FROM', default=ADMINS[0])
+
+if django.VERSION >= (3, 2):
+    ADMINS = (('ASI Notifications', 'asi@dpaw.wa.gov.au',),)
+    EMAIL_FROM = decouple.config('EMAIL_FROM', default=ADMINS[0][1])
+else:
+    ADMINS = ('asi@dpaw.wa.gov.au',)
+    EMAIL_FROM = decouple.config('EMAIL_FROM', default=ADMINS[0])
+
 DEFAULT_FROM_EMAIL = EMAIL_FROM
 
 TEMPLATES = [


### PR DESCRIPTION
From django 3.2 onwards ADMINS should be either list of tuples or tuple or tuples otherwise will raise ValueError in mail_admins function and no exception email will be sent.

Relevant code in django that raises the error since version 3.2:

https://github.com/django/django/blob/b6475d7d7940f3ce575e0b0f2d83e517f899b4cf/django/core/mail/__init__.py#L95